### PR TITLE
[Fix] GET my-groups API 라우팅 오류 수정 및 그룹 인원 수 반환

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -26,6 +26,17 @@ export class GroupsController {
     return this.groupsService.getAllGroups();
   }
 
+  @Get('/my-groups')
+  @ApiOperation({
+    summary: '가입 그룹 확인',
+    description: '해당 사용자가 가입한 그룹을 확인합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully Check', type: [GroupsDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyGroups(@GetUser() member: Member): Promise<(Group & { membersCount: number })[]> {
+    return this.groupsService.getMyGroups(member);
+  }
+
   @Get('/info')
   @ApiOperation({
     summary: '승인코드를 사용하여 그룹 정보 추출',
@@ -103,16 +114,5 @@ export class GroupsController {
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);
-  }
-
-  @Get('/my-groups')
-  @ApiOperation({
-    summary: '가입 그룹 확인',
-    description: '해당 사용자가 가입한 그룹을 확인합니다.',
-  })
-  @ApiResponse({ status: 200, description: 'Successfully Check', type: [GroupsDto] })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getMyGroups(@GetUser() member: Member): Promise<Group[]> {
-    return this.groupsService.getMyGroups(member);
   }
 }

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -36,7 +36,7 @@ export class GroupsService {
     return this.groupsRepository.leaveGroup(id, member);
   }
 
-  async getMyGroups(member: Member): Promise<Group[]> {
+  async getMyGroups(member: Member): Promise<(Group & { membersCount: number })[]> {
     return this.groupsRepository.getMyGroups(member);
   }
 }


### PR DESCRIPTION
## 설명
- close #1 

```
{
    "message": "Validation failed (numeric string is expected)",
    "error": "Bad Request",
    "statusCode": 400
}
```
위와 같은 오류가 또다시 발생함

[이전에 겪은 기록](https://velog.io/@ldhbenecia/NestJS-Validation-failed-%EB%9D%BC%EC%9A%B0%ED%8C%85-%EC%8B%9C%EC%8A%A4%ED%85%9C%EC%9C%BC%EB%A1%9C-%EC%9D%B8%ED%95%9C-%EC%98%A4%EB%A5%98)

## 완료한 기능 명세
- [x] GET my-groups API 라우팅 오류 수정
- [x] 그룹 인원 수 반환

### 스크린샷
<img width="792" alt="스크린샷 2024-02-04 오후 1 04 51" src="https://github.com/team-morak/morak/assets/77393976/a609f6c0-764f-4731-b97e-cf7ae0544944">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

