### PR TITLE
[Feat] my-groups API에 access_code 추가 반환

### DIFF
--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -26,6 +26,17 @@ export class GroupsController {
     return this.groupsService.getAllGroups();
   }
 
+  @Get('/my-groups')
+  @ApiOperation({
+    summary: '가입 그룹 확인',
+    description: '해당 사용자가 가입한 그룹을 확인합니다.',
+  })
+  @ApiResponse({ status: 200, description: 'Successfully Check', type: [GroupsDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyGroups(@GetUser() member: Member): Promise<(Group & { membersCount: number })[]> {
+    return this.groupsService.getMyGroups(member);
+  }
+
   @Get('/info')
   @ApiOperation({
     summary: '승인코드를 사용하여 그룹 정보 추출',
@@ -103,16 +114,5 @@ export class GroupsController {
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
     return this.groupsService.leaveGroup(id, member);
-  }
-
-  @Get('/my-groups')
-  @ApiOperation({
-    summary: '가입 그룹 확인',
-    description: '해당 사용자가 가입한 그룹을 확인합니다.',
-  })
-  @ApiResponse({ status: 200, description: 'Successfully Check', type: [GroupsDto] })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getMyGroups(@GetUser() member: Member): Promise<Group[]> {
-    return this.groupsService.getMyGroups(member);
   }
 }

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -36,7 +36,7 @@ export class GroupsService {
     return this.groupsRepository.leaveGroup(id, member);
   }
 
-  async getMyGroups(member: Member): Promise<Group[]> {
+  async getMyGroups(member: Member): Promise<(Group & { membersCount: number })[]> {
     return this.groupsRepository.getMyGroups(member);
   }
 }


### PR DESCRIPTION
## 설명
- close #5 

지승님과 2024.02.05(월) 16시 경 디스코드를 통해서 플로우를 한번 더 확인하고 그에 따라 필요한 데이터를 추가적으로 반환합니다.
클라이언트에서는 본인의 그룹을 확인하였을 때 승인코드 또한 밑에 보여줄 것이며, 그것을 복사해서 뿌릴 것이기 때문에
본인의 그룹을 조회하는 my-groups API에 승인 코드 또한 필요합니다.

## 완료한 기능 명세
- [x] my-groups API에 access_code 추가 반환

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기

<img width="804" alt="image" src="https://github.com/team-morak/morak/assets/77393976/dfd0f812-ad0a-4592-87fa-d99d73ac70e7">


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

@js43o 
