### PR TITLE
[Feat] 그룹 생성 페이지 API 연결

### DIFF
--- a/app/frontend/src/components/Group/hooks/useGroupJoinLeave.tsx
+++ b/app/frontend/src/components/Group/hooks/useGroupJoinLeave.tsx
@@ -3,8 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/queries';
 import { useJoinGroupQuery, useLeaveGroupQuery } from '@/queries/hooks/group';
 
-import { Modal } from '../../Modal';
-
 export const useGroupJoinAndLeave = () => {
   const { mutate: leaveGroup } = useLeaveGroupQuery();
   const { mutate: joinGroup } = useJoinGroupQuery();

--- a/app/frontend/src/components/Modal/Footer.tsx
+++ b/app/frontend/src/components/Modal/Footer.tsx
@@ -30,7 +30,7 @@ export function Footer({
         shape="fill"
         size="large"
         fullWidth
-        onClick={buttonType === 'double' ? confirmModal : closeModal}
+        onClick={confirmModal}
       >
         {confirmButtonText}
       </Button>

--- a/app/frontend/src/pages/Groups/Create/GroupTypeRadio.tsx
+++ b/app/frontend/src/pages/Groups/Create/GroupTypeRadio.tsx
@@ -1,28 +1,32 @@
 import { Control, useController } from 'react-hook-form';
 
+import { RequestGroupsDto } from '@morak/apitype';
 import { Radio } from '@morak/ui';
 
 import * as styles from './index.css';
-import { GroupCreate } from './types';
 
-export function GroupTypeRadio({ control }: { control: Control<GroupCreate> }) {
+export function GroupTypeRadio({
+  control,
+}: {
+  control: Control<RequestGroupsDto>;
+}) {
   const {
     field: { value, onChange },
   } = useController({
-    name: 'type',
+    name: 'groupTypeId',
     control,
   });
 
   return (
     <div className={styles.groupWrapper}>
-      {['public', 'private'].map((type) => (
+      {[1, 0].map((type) => (
         <Radio
           key={type}
-          id={type}
+          id={`${type}`}
           checked={value === type}
           onChange={(e) => onChange(e.target.id)}
         >
-          {type === 'public' ? '공개' : '비공개'} 그룹
+          {type ? '공개' : '비공개'} 그룹
         </Radio>
       ))}
     </div>

--- a/app/frontend/src/pages/Groups/Create/index.tsx
+++ b/app/frontend/src/pages/Groups/Create/index.tsx
@@ -1,23 +1,23 @@
 import { useController, useForm } from 'react-hook-form';
 
+import { RequestGroupsDto } from '@morak/apitype';
 import { TextLabel, Button } from '@morak/ui';
 
 import { FormInput } from '@/components';
+import { useLeaveGroupQuery } from '@/queries/hooks/group';
 
 import { GroupTypeRadio } from './GroupTypeRadio';
 import * as styles from './index.css';
-import { GroupCreate } from './types';
 
 export function GroupCreatePage() {
   const {
     control,
     handleSubmit,
     formState: { isValid },
-  } = useForm<GroupCreate>({
+  } = useForm<RequestGroupsDto>({
     defaultValues: {
-      name: '',
-      type: 'public',
-      joinType: ['approve'],
+      title: '',
+      groupTypeId: 1,
     },
     mode: 'all',
   });
@@ -25,17 +25,22 @@ export function GroupCreatePage() {
   const {
     field: { value: nameValue, onChange: onChangeName },
   } = useController({
-    name: 'name',
+    name: 'title',
     control,
     rules: {
       required: true,
     },
   });
+
+  const { mutate } = useLeaveGroupQuery();
+
   return (
     <form
       className={styles.container}
       // TODO: POST 요청
-      onSubmit={handleSubmit((data) => console.log(data))}
+      onSubmit={handleSubmit((data) => {
+        mutate(data);
+      })}
     >
       <FormInput
         label="그룹명"

--- a/app/frontend/src/pages/Groups/Create/index.tsx
+++ b/app/frontend/src/pages/Groups/Create/index.tsx
@@ -1,9 +1,11 @@
 import { useController, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { RequestGroupsDto } from '@morak/apitype';
 import { TextLabel, Button } from '@morak/ui';
 
-import { FormInput } from '@/components';
+import { FormInput, Modal } from '@/components';
+import { useModal } from '@/hooks';
 import { useLeaveGroupQuery } from '@/queries/hooks/group';
 
 import { GroupTypeRadio } from './GroupTypeRadio';
@@ -32,16 +34,26 @@ export function GroupCreatePage() {
     },
   });
 
-  const { mutate } = useLeaveGroupQuery();
+  const { mutateAsync } = useLeaveGroupQuery();
+
+  const { openModal } = useModal();
+  const navigate = useNavigate();
+  const submitGroup = async (data: RequestGroupsDto) => {
+    const { status } = await mutateAsync(data);
+    // TODO: 에러 처리
+    if (status === 201) {
+      openModal(
+        <Modal
+          title="그룹이 생성되었습니다."
+          buttonType="single"
+          onClickConfirm={() => navigate('/groups')}
+        />,
+      );
+    }
+  };
 
   return (
-    <form
-      className={styles.container}
-      // TODO: POST 요청
-      onSubmit={handleSubmit((data) => {
-        mutate(data);
-      })}
-    >
+    <form className={styles.container} onSubmit={handleSubmit(submitGroup)}>
       <FormInput
         label="그룹명"
         required

--- a/app/frontend/src/pages/Groups/Create/index.tsx
+++ b/app/frontend/src/pages/Groups/Create/index.tsx
@@ -6,7 +6,7 @@ import { TextLabel, Button } from '@morak/ui';
 
 import { FormInput, Modal } from '@/components';
 import { useModal } from '@/hooks';
-import { useLeaveGroupQuery } from '@/queries/hooks/group';
+import { useCreateGroupQuery } from '@/queries/hooks/group';
 
 import { GroupTypeRadio } from './GroupTypeRadio';
 import * as styles from './index.css';
@@ -34,7 +34,7 @@ export function GroupCreatePage() {
     },
   });
 
-  const { mutateAsync } = useLeaveGroupQuery();
+  const { mutateAsync } = useCreateGroupQuery();
 
   const { openModal } = useModal();
   const navigate = useNavigate();

--- a/app/frontend/src/queries/hooks/group.ts
+++ b/app/frontend/src/queries/hooks/group.ts
@@ -8,10 +8,10 @@ export const useCreateGroupQuery = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => group.leave({ id }),
+    mutationFn: (form: RequestGroupsDto) => group.create(form),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.group.myGroup().queryKey,
+        queryKey: queryKeys.group.all().queryKey,
       });
     },
   });
@@ -34,10 +34,10 @@ export const useLeaveGroupQuery = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (form: RequestGroupsDto) => group.create(form),
+    mutationFn: (id: string) => group.leave({ id }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.group.all().queryKey,
+        queryKey: queryKeys.group.myGroup().queryKey,
       });
     },
   });

--- a/app/frontend/src/queries/hooks/group.ts
+++ b/app/frontend/src/queries/hooks/group.ts
@@ -1,7 +1,21 @@
+import { RequestGroupsDto } from '@morak/apitype';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { queryKeys } from '@/queries';
 import { group } from '@/services';
+
+export const useCreateGroupQuery = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => group.leave({ id }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.group.myGroup().queryKey,
+      });
+    },
+  });
+};
 
 export const useJoinGroupQuery = () => {
   const queryClient = useQueryClient();
@@ -20,10 +34,10 @@ export const useLeaveGroupQuery = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => group.leave({ id }),
+    mutationFn: (form: RequestGroupsDto) => group.create(form),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.group.myGroup().queryKey,
+        queryKey: queryKeys.group.all().queryKey,
       });
     },
   });

--- a/app/frontend/src/services/group.ts
+++ b/app/frontend/src/services/group.ts
@@ -1,4 +1,4 @@
-import { ResponseGroupsDto } from '@morak/apitype';
+import { RequestGroupsDto, ResponseGroupsDto } from '@morak/apitype';
 
 import { morakAPI } from './morakAPI';
 
@@ -23,4 +23,6 @@ export const group = {
     morakAPI.post<null>(`${group.endPoint.default}/${id}/join`),
   leave: async ({ id }: Pick<ResponseGroupsDto, 'id'>) =>
     morakAPI.delete<null>(`${group.endPoint.default}/${id}/leave`),
+  create: async (form: RequestGroupsDto) =>
+    morakAPI.post<null>(group.endPoint.default, form),
 };


### PR DESCRIPTION
<!--
### 체크 리스트

 * merge할 대상 브랜치 위치를 확인 (develop :x:)
 * 이전 PR 커밋들이 포함되지 않았는가 확인 (이후에 작성된 커밋만 포함)
 * PR 보낸 후 충돌이 나지 않는지 확인 (충돌 해결 필수)
 
 * PR 머지 시 이슈 close 필요한 경우 종료 키워드 함께 작성
   * 또는 link issue 사용
 * PR 머지 시 이슈 close 필요하지 않은 경우 이슈 멘션만 하기

### PR 메시지 
 1. 제목: [Feat] 어쩌고저쩌고 화면 구현
		Feat/Fix/Refactor/...
 2. 내용
		이슈 링크하기
-->

## 설명
- closed #20 

## 완료한 기능 명세
- [x] 그룹 생성 페이지 API 연결
  - service /group POST 추가
  - queries 그룹 생성 훅 추가 
  - 그룹 생성 성공 시 모달 띄우고 모달 확인 버튼 클릭 시 그룹 리스트로 이동
    - 싱글 모달도 onClickConfirm 사용할 수 있도록 수정하였음

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

