### PR TITLE
[Refactor] 그룹 생성 시 groupTypeId Swagger 추가 설정

### DIFF
--- a/app/backend/src/groups/dto/create-groups.dto.ts
+++ b/app/backend/src/groups/dto/create-groups.dto.ts
@@ -7,6 +7,7 @@ export class CreateGroupsDto implements RequestGroupsDto {
   @IsNotEmpty()
   title: string;
 
+  @ApiProperty({ description: 'typeId of the Group, 0: 공개, 1: 비공개', example: '0' })
   @IsInt()
   groupTypeId: number;
 }

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -81,10 +81,7 @@ export class GroupsController {
   @ApiBody({ type: CreateGroupsDto })
   @ApiResponse({ status: 201, description: 'Successfully created' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async createGroups(
-    @Body() createGroupsDto: CreateGroupsDto,
-    @GetUser() member: Member,
-  ): Promise<{ group: Group; accessCode: string }> {
+  async createGroups(@Body() createGroupsDto: CreateGroupsDto, @GetUser() member: Member): Promise<void> {
     return this.groupsService.createGroups(createGroupsDto, member);
   }
 

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -79,7 +79,7 @@ export class GroupsController {
     description: '새로운 그룹을 생성합니다.',
   })
   @ApiBody({ type: CreateGroupsDto })
-  @ApiResponse({ status: 201, description: 'Successfully created', type: CreateGroupsDto })
+  @ApiResponse({ status: 201, description: 'Successfully created' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async createGroups(
     @Body() createGroupsDto: CreateGroupsDto,

--- a/app/backend/src/groups/groups.repository.ts
+++ b/app/backend/src/groups/groups.repository.ts
@@ -90,7 +90,7 @@ export class GroupsRepository {
     }));
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<{ group: Group; accessCode: string }> {
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<void> {
     const { title, groupTypeId } = createGroupsDto;
 
     const group = await this.prisma.group.create({
@@ -112,8 +112,6 @@ export class GroupsRepository {
     });
 
     await this.joinGroup(Number(group.id), member);
-
-    return { group, accessCode };
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -24,7 +24,7 @@ export class GroupsService {
     return this.groupsRepository.getAllMembersOfGroup(id);
   }
 
-  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<{ group: Group; accessCode: string }> {
+  async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<void> {
     return this.groupsRepository.createGroups(createGroupsDto, member);
   }
 


### PR DESCRIPTION
## 설명
- close #17 
- 저번 작업으로 groupTypeId도 입력받게 하였는데 Swagger 작성을 잊어서 추가합니다.
- Post 요청인 그룹 생성은 반환 값이 필요없기 떄문에 반환 타입을 void로 수정합니다.

## 완료한 기능 명세
- [x] 그룹 생성 시 groupTypeId Swagger 추가 설정

### 스크린샷
<img width="1378" alt="image" src="https://github.com/team-morak/morak/assets/77393976/4da70a58-1273-4c95-a08a-4a6ab11bf0fe">

<img width="790" alt="image" src="https://github.com/team-morak/morak/assets/77393976/2652a3c0-364b-4e6b-873f-5d569a4c4436">

<img width="437" alt="image" src="https://github.com/team-morak/morak/assets/77393976/82c388c2-8b2c-465f-a5f6-ecee7d25a3b3">

<img width="388" alt="image" src="https://github.com/team-morak/morak/assets/77393976/7297826a-9e3b-4bbe-a092-d905946bfeb2">

그룹을 생성하면 다음과 같이 DB에 그룹 생성자의 id, 그룹 타입 id가 기록됩니다.
그리고 그룹의 액세스 코드 DB에 액세스 코드가 추가됩니다.


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

