### PR TITLE
[Feat] 그룹 멤버 강제 퇴장 API 구현

### DIFF
--- a/app/backend/src/groups/dto/groups.dto.ts
+++ b/app/backend/src/groups/dto/groups.dto.ts
@@ -1,5 +1,5 @@
 import {
-  ResponseAccesCodeByGroupsDto,
+  ResponseAccessCodeByGroupsDto,
   ResponseGroupsDto,
   ResponseGroupsWithMemberCountDto,
   ResponseMyGroupsDto,
@@ -52,7 +52,7 @@ export class MyGroupsDto implements ResponseMyGroupsDto {
   accessCode: string;
 }
 
-export class AccessCodeByGroupsDto implements ResponseAccesCodeByGroupsDto {
+export class AccessCodeByGroupsDto implements ResponseAccessCodeByGroupsDto {
   @ApiProperty({ description: 'ID of the Group', example: '1' })
   id: Bigint;
 

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -23,7 +23,7 @@ export class GroupsController {
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [GroupsWithMemberCountDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllGroups(): Promise<(Group & { membersCount: number })[]> {
-    return this.groupsService.getAllGroups();
+    return await this.groupsService.getAllGroups();
   }
 
   @Get('/my-groups')
@@ -34,7 +34,7 @@ export class GroupsController {
   @ApiResponse({ status: 200, description: 'Successfully Check', type: [MyGroupsDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyGroups(@GetUser() member: Member): Promise<(Group & { membersCount: number })[]> {
-    return this.groupsService.getMyGroups(member);
+    return await this.groupsService.getMyGroups(member);
   }
 
   @Get('/info')
@@ -46,7 +46,7 @@ export class GroupsController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Group not found for the provided access code' })
   async getGroupByAccessCode(@Query('access_code') accessCode: string): Promise<Group & { membersCount: number }> {
-    return this.groupsService.getGroupByAccessCode(accessCode);
+    return await this.groupsService.getGroupByAccessCode(accessCode);
   }
 
   @Get('/:id')
@@ -58,7 +58,7 @@ export class GroupsController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async getGroups(@Param('id', ParseIntPipe) id: number): Promise<Group & { membersCount: number }> {
-    return this.groupsService.getGroups(id);
+    return await this.groupsService.getGroups(id);
   }
 
   @Get('/:id/members')
@@ -70,7 +70,7 @@ export class GroupsController {
   @ApiResponse({ status: 200, description: 'Successfully retrieved', type: [ParticipantResponseDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllMembersOfGroup(@Param('id', ParseIntPipe) id: number): Promise<MemberInformationDto[]> {
-    return this.groupsService.getAllMembersOfGroup(id);
+    return await this.groupsService.getAllMembersOfGroup(id);
   }
 
   @Post('/')
@@ -82,7 +82,7 @@ export class GroupsController {
   @ApiResponse({ status: 201, description: 'Successfully created' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async createGroups(@Body() createGroupsDto: CreateGroupsDto, @GetUser() member: Member): Promise<void> {
-    return this.groupsService.createGroups(createGroupsDto, member);
+    await this.groupsService.createGroups(createGroupsDto, member);
   }
 
   @Post('/:id/join')
@@ -96,7 +96,7 @@ export class GroupsController {
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async joinGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
-    return this.groupsService.joinGroup(id, member);
+    await this.groupsService.joinGroup(id, member);
   }
 
   @Delete('/:id/leave')
@@ -109,6 +109,24 @@ export class GroupsController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Group with id not found' })
   async leaveGroup(@Param('id', ParseIntPipe) id: number, @GetUser() member: Member): Promise<void> {
-    return this.groupsService.leaveGroup(id, member);
+    await this.groupsService.leaveGroup(id, member);
+  }
+
+  @Delete('/:id/kick/:memberId')
+  @ApiOperation({
+    summary: '멤버 강제퇴장',
+    description: '특정 그룹에서 멤버를 강제로 퇴장시킵니다.',
+  })
+  @ApiParam({ name: 'groupId', description: '멤버를 강제로 퇴장시킬 그룹의 Id' })
+  @ApiParam({ name: 'memberId', description: '강제로 퇴장시킬 멤버의 Id' })
+  @ApiResponse({ status: 200, description: 'Successfully kicked out the member' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Group or member not found' })
+  async kickOutMember(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('memberId', ParseIntPipe) memberId: number,
+    @GetUser() groupOwner: Member,
+  ): Promise<void> {
+    await this.groupsService.kickOutMember(id, memberId, groupOwner);
   }
 }

--- a/app/backend/src/groups/groups.controller.ts
+++ b/app/backend/src/groups/groups.controller.ts
@@ -121,6 +121,7 @@ export class GroupsController {
   @ApiParam({ name: 'memberId', description: '강제로 퇴장시킬 멤버의 Id' })
   @ApiResponse({ status: 200, description: 'Successfully kicked out the member' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Only group owners can kick out members.' })
   @ApiResponse({ status: 404, description: 'Group or member not found' })
   async kickOutMember(
     @Param('id', ParseIntPipe) id: number,

--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -9,34 +9,38 @@ export class GroupsService {
   constructor(private groupsRepository: GroupsRepository) {}
 
   async getAllGroups(): Promise<(Group & { membersCount: number })[]> {
-    return this.groupsRepository.getAllGroups();
+    return await this.groupsRepository.getAllGroups();
   }
 
   async getGroupByAccessCode(accessCode: string): Promise<Group & { membersCount: number }> {
-    return this.groupsRepository.getGroupByAccessCode(accessCode);
+    return await this.groupsRepository.getGroupByAccessCode(accessCode);
   }
 
   async getGroups(id: number): Promise<Group & { membersCount: number }> {
-    return this.groupsRepository.getGroups(id);
+    return await this.groupsRepository.getGroups(id);
   }
 
   async getAllMembersOfGroup(id: number): Promise<MemberInformationDto[]> {
-    return this.groupsRepository.getAllMembersOfGroup(id);
+    return await this.groupsRepository.getAllMembersOfGroup(id);
   }
 
   async createGroups(createGroupsDto: CreateGroupsDto, member: Member): Promise<void> {
-    return this.groupsRepository.createGroups(createGroupsDto, member);
+    await this.groupsRepository.createGroups(createGroupsDto, member);
   }
 
   async joinGroup(id: number, member: Member): Promise<void> {
-    return this.groupsRepository.joinGroup(id, member);
+    await this.groupsRepository.joinGroup(id, member);
   }
 
   async leaveGroup(id: number, member: Member): Promise<void> {
-    return this.groupsRepository.leaveGroup(id, member);
+    await this.groupsRepository.leaveGroup(id, member);
   }
 
   async getMyGroups(member: Member): Promise<(Group & { membersCount: number })[]> {
-    return this.groupsRepository.getMyGroups(member);
+    return await this.groupsRepository.getMyGroups(member);
+  }
+
+  async kickOutMember(id: number, memberId: number, groupOwner: Member): Promise<void> {
+    await this.groupsRepository.kickOutMember(id, memberId, groupOwner);
   }
 }

--- a/packages/apitype/dto/response/groups.ts
+++ b/packages/apitype/dto/response/groups.ts
@@ -22,7 +22,7 @@ export interface ResponseMyGroupsDto {
   accessCode: string;
 }
 
-export interface ResponseAccesCodeByGroupsDto {
+export interface ResponseAccessCodeByGroupsDto {
   id: Bigint;
   title: string;
   groupOwnerId: Bigint;


### PR DESCRIPTION
## 설명
- close #19 
- 그룹장은 그룹 멤버를 강제 퇴장 시킬 수 있습니다.
- 그룹장이 아닌 사람은 할 수 없습니다.

## 완료한 기능 명세
- [x] 그룹 멤버 강제 퇴장 API 구현
- [x] ResponseAccessCodeByGroupsDto 맞춤법 오탈자 수정

### 스크린샷

1. 다음과 같이 7번 그룹에 1, 2번의 아이디를 가진 그룹 참가자가 존재합니다.
<img width="446" alt="스크린샷 2024-02-26 오후 3 45 05" src="https://github.com/team-morak/morak/assets/77393976/1da392ce-88de-44ea-8f87-43abfce4a27d">

2. 2번 참가자가 그룹장을 강제퇴장 시켜려고 하면 그룹장이 아니기 때문에 403 에러를 반환합니다.
<img width="790" alt="스크린샷 2024-02-26 오후 3 46 30" src="https://github.com/team-morak/morak/assets/77393976/b697124b-795b-42c0-8162-a95baaa4c020">

3. 그룹장이 2번 참가자를 강제퇴장 하면 성공합니다.
<img width="808" alt="스크린샷 2024-02-26 오후 3 47 23" src="https://github.com/team-morak/morak/assets/77393976/a4709026-88d8-4ec5-a63d-a57437b113da">

4. DB 확인 시 사라짐을 확인 가능합니다.
<img width="448" alt="스크린샷 2024-02-26 오후 3 47 29" src="https://github.com/team-morak/morak/assets/77393976/062b92ab-14b0-4f1b-b017-310db8f4d24c">


- Swagger
<img width="1387" alt="image" src="https://github.com/team-morak/morak/assets/77393976/f48aee1e-ae19-48fe-8c4e-7dfe0ab7456b">

## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

지승님께서 발견하신 ResponseAccessCodeByGroupsDto 오탈자 수정하였습니다.
@ttaerrim @LEEJW1953 @js43o 

