### PR TITLE
[Refactor] 충돌 수정 이후 memberCount 변수명 재수정

### DIFF
--- a/app/backend/src/groups/groups.service.ts
+++ b/app/backend/src/groups/groups.service.ts
@@ -53,6 +53,7 @@ export class GroupsService {
 
   async getMyGroups(member: Member): Promise<(Group & { memberCount: number })[]> {
     return await this.groupsRepository.getMyGroups(member);
+  }
 
   async kickOutMember(id: number, memberId: number, groupOwner: Member): Promise<void> {
     await this.groupsRepository.kickOutMember(id, memberId, groupOwner);


### PR DESCRIPTION
## 설명
- #30
이전 PR에서 develop을 병합하지않고 PR을 올려서 충돌난 것을 해결했습니다.
그런데 해결하며 중괄호가 하나 빠지고 병합한 내용에서 또 membersCount가 발견되어서 수정합니다.

## 완료한 기능 명세
- [x] 충돌 수정 이후 memberCount 변수명 재 수정

### 스크린샷
> 기능 작업에 대한 스크린샷/화면 녹화 있을 경우 첨부하기


## 리뷰 요청 사항
> 특별히 리뷰해 주었으면 하는 부분, 고민되는 부분 기재하기

