### PR TITLE
[Feat] 그룹 가입 신청 API 연동

### DIFF
--- a/app/frontend/src/components/Group/GroupButton.tsx
+++ b/app/frontend/src/components/Group/GroupButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@morak/ui';
 
+import { useGroupApply } from './hooks/useGroupApply';
 import { useGroupJoinAndLeave } from './hooks/useGroupJoinLeave';
 import { useGroupModal } from './hooks/useGroupModal';
 
@@ -12,6 +13,7 @@ type GroupButtonProps = {
 
 export function GroupButton({ id, closed, joined, owned }: GroupButtonProps) {
   const { handleLeave, handleJoin } = useGroupJoinAndLeave();
+  const { handleApply } = useGroupApply();
   const { openLeaveModal, openJoinModal, openApplyModal } = useGroupModal();
 
   const onClickLeave = () =>
@@ -20,9 +22,7 @@ export function GroupButton({ id, closed, joined, owned }: GroupButtonProps) {
     openJoinModal({ onClickConfirm: () => handleJoin(id) });
   const onClickApply = () =>
     openApplyModal({
-      onClickConfirm: () => {
-        // 가입 신청 API 연동
-      },
+      onClickConfirm: () => handleApply(id),
     });
 
   return (

--- a/app/frontend/src/components/Group/hooks/useGroupApply.tsx
+++ b/app/frontend/src/components/Group/hooks/useGroupApply.tsx
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { Modal } from '@/components';
+import { useModal } from '@/hooks';
+import { group } from '@/services';
+
+export const useGroupApply = () => {
+  const { mutate } = useMutation({
+    mutationFn: (id: string) => group.apply({ id }),
+  });
+  const { openModal } = useModal();
+
+  const handleApply = async (id: string) => {
+    mutate(id, {
+      onSuccess: () =>
+        openModal(
+          <Modal title="가입 신청이 완료되었습니다." buttonType="single" />,
+        ),
+      onError: () =>
+        openModal(
+          <Modal title="가입 신청에 실패했습니다." buttonType="single" />,
+        ),
+    });
+  };
+
+  return { handleApply };
+};

--- a/app/frontend/src/components/Group/hooks/useGroupJoinLeave.tsx
+++ b/app/frontend/src/components/Group/hooks/useGroupJoinLeave.tsx
@@ -3,8 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/queries';
 import { useJoinGroupQuery, useLeaveGroupQuery } from '@/queries/hooks/group';
 
-import { Modal } from '../../Modal';
-
 export const useGroupJoinAndLeave = () => {
   const { mutate: leaveGroup } = useLeaveGroupQuery();
   const { mutate: joinGroup } = useJoinGroupQuery();

--- a/app/frontend/src/services/group.ts
+++ b/app/frontend/src/services/group.ts
@@ -49,4 +49,6 @@ export const group = {
     morakAPI.post<null>(`${group.endPoint.default}/${id}/join`),
   leave: async ({ id }: Pick<ResponseGroupsDto, 'id'>) =>
     morakAPI.delete<null>(`${group.endPoint.default}/${id}/leave`),
+  apply: async ({ id }: Pick<ResponseGroupsDto, 'id'>) =>
+    morakAPI.post<null>(`${group.endPoint.default}/${id}/apply`),
 };


### PR DESCRIPTION
## 설명
- close #33 
- 비공개 그룹에 가입 신청을 위한 API를 연동합니다.
- 이미 가입 신청했던 그룹에 다시 가입 신청을 하더라도 정상적으로 '가입 신청 완료' 알림을 표시하도록 했습니다. (네트워크 에러 등의 상황에서만 실패 알림 표시)

## 완료한 기능 명세
- [x] 가입 신청 API 함수 및 `useGroupApply` 훅 추가

### 스크린샷
![image](https://github.com/team-morak/morak/assets/50646827/2bb8607d-834e-438c-8317-e03c64b335ee)
![image](https://github.com/team-morak/morak/assets/50646827/75c57b59-12bf-4aa2-905d-fcda385a1ffa)

## 리뷰 요청 사항

